### PR TITLE
Add callout block markdown syntax

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -195,6 +195,11 @@ type Aside struct {
 	Container
 }
 
+// CalloutBlock represents a callout block node
+type CalloutBlock struct {
+	Container
+}
+
 // List represents markdown list node
 type List struct {
 	Container

--- a/callout_block_test.go
+++ b/callout_block_test.go
@@ -1,0 +1,20 @@
+package markdown
+
+import (
+	"testing"
+
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
+)
+
+func TestCalloutBlock(t *testing.T) {
+	tests := []string{
+		"( Callout line 1\n( Callout line 2\n\nAfter\n",
+		"<div class=\"callout\">\n<p>Callout line 1\nCallout line 2</p>\n</div>\n<p>After</p>\n",
+	}
+	params := TestParams{
+		extensions: parser.CommonExtensions | parser.Callouts,
+		Flags:      html.UseXHTML,
+	}
+	doTestsParam(t, tests, params)
+}

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -572,6 +572,10 @@ func (r *Renderer) paragraphEnter(w io.Writer, para *ast.Paragraph) {
 		if isParentAside {
 			r.CR(w)
 		}
+		_, isParentCallout := para.Parent.(*ast.CalloutBlock)
+		if isParentCallout {
+			r.CR(w)
+		}
 	}
 
 	ptag := "<p"
@@ -993,6 +997,14 @@ func (r *Renderer) Callout(w io.Writer, node *ast.Callout) {
 	r.Outs(w, "</span>")
 }
 
+// CalloutBlock writes ast.CalloutBlock node
+func (r *Renderer) CalloutBlock(w io.Writer, node *ast.CalloutBlock, entering bool) {
+	attrs := []string{`class="callout"`}
+	attrs = append(attrs, BlockAttrs(node)...)
+	tag := TagWithAttributes("<div", attrs)
+	r.OutOneOfCr(w, entering, tag, "</div>")
+}
+
 // Index writes ast.Index node
 func (r *Renderer) Index(w io.Writer, node *ast.Index) {
 	// there is no in-text representation.
@@ -1028,6 +1040,8 @@ func (r *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.Wal
 	case *ast.BlockQuote:
 		tag := TagWithAttributes("<blockquote", BlockAttrs(node))
 		r.OutOneOfCr(w, entering, tag, "</blockquote>")
+	case *ast.CalloutBlock:
+		r.CalloutBlock(w, node, entering)
 	case *ast.Aside:
 		tag := TagWithAttributes("<aside", BlockAttrs(node))
 		r.OutOneOfCr(w, entering, tag, "</aside>")

--- a/parser/block.go
+++ b/parser/block.go
@@ -279,6 +279,17 @@ func (p *Parser) Block(data []byte) {
 			continue
 		}
 
+		// callout:
+		//
+		// ( This is a callout
+		// ( spanning multiple lines
+		if p.extensions&Callouts != 0 {
+			if p.calloutPrefix(data) > 0 {
+				data = data[p.callout(data):]
+				continue
+			}
+		}
+
 		// aside:
 		//
 		// A> The proof is too large to fit

--- a/parser/callout_block.go
+++ b/parser/callout_block.go
@@ -1,0 +1,72 @@
+package parser
+
+import (
+	"bytes"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+// returns callout prefix length
+func (p *Parser) calloutPrefix(data []byte) int {
+	i := 0
+	n := len(data)
+	for i < 3 && i < n && data[i] == ' ' {
+		i++
+	}
+	if i < n && data[i] == '(' {
+		if i+1 < n && data[i+1] == ' ' {
+			return i + 2
+		}
+		return i + 1
+	}
+	return 0
+}
+
+// callout ends with at least one blank line
+// followed by something without a callout prefix
+func (p *Parser) terminateCallout(data []byte, beg, end int) bool {
+	if IsEmpty(data[beg:]) <= 0 {
+		return false
+	}
+	if end >= len(data) {
+		return true
+	}
+	return p.calloutPrefix(data[end:]) == 0 && IsEmpty(data[end:]) == 0
+}
+
+// parse a callout fragment
+func (p *Parser) callout(data []byte) int {
+	var raw bytes.Buffer
+	beg, end := 0, 0
+	for beg < len(data) {
+		end = beg
+		// Step over whole lines, collecting them. While doing that, check for
+		// fenced code and if one's found, incorporate it altogether,
+		// irregardless of any contents inside it
+		for end < len(data) && data[end] != '\n' {
+			if p.extensions&FencedCode != 0 {
+				if i := p.fencedCodeBlock(data[end:], false); i > 0 {
+					// -1 to compensate for the extra end++ after the loop:
+					end += i - 1
+					break
+				}
+			}
+			end++
+		}
+		end = skipCharN(data, end, '\n', 1)
+		if pre := p.calloutPrefix(data[beg:]); pre > 0 {
+			// skip the prefix
+			beg += pre
+		} else if p.terminateCallout(data, beg, end) {
+			break
+		}
+		// this line is part of the callout
+		raw.Write(data[beg:end])
+		beg = end
+	}
+
+	block := p.AddBlock(&ast.CalloutBlock{})
+	p.Block(raw.Bytes())
+	p.Finalize(block)
+	return end
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -45,6 +45,7 @@ const (
 	EmptyLinesBreakList                           // 2 empty lines break out of list
 	Includes                                      // Support including other files.
 	Mmark                                         // Support Mmark syntax, see https://mmark.miek.nl/post/syntax/
+	Callouts                                      // Support callout blocks using '(' prefix
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
 		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |
@@ -233,7 +234,7 @@ func canNodeContain(n ast.Node, v ast.Node) bool {
 	switch n.(type) {
 	case *ast.List:
 		return isListItem(v)
-	case *ast.Document, *ast.BlockQuote, *ast.Aside, *ast.ListItem, *ast.CaptionFigure:
+	case *ast.Document, *ast.BlockQuote, *ast.Aside, *ast.ListItem, *ast.CaptionFigure, *ast.CalloutBlock:
 		return !isListItem(v)
 	case *ast.Table:
 		switch v.(type) {


### PR DESCRIPTION
## Summary
- introduce `CalloutBlock` AST node and `Callouts` parser extension
- parse lines starting with `(` into callout blocks and render as `<div class="callout">`
- add unit test covering callout block HTML output

## Testing
- `go test ./ast ./html ./parser .`
- `go test ./md` *(fails: TestRenderCodeBlock)*

------
https://chatgpt.com/codex/tasks/task_e_68c43da4cc9883228c8ac47f84bb4fe0